### PR TITLE
fix query_resource_group_default_cpu_used_permille_limit

### DIFF
--- a/flavius/templates/configmap.yaml
+++ b/flavius/templates/configmap.yaml
@@ -89,7 +89,7 @@ data:
     query_resource_group_default_cpu_core_limit = {{ include "flavius.toCores" .Values.cn.resources.limits.cpu }}
     query_resource_group_default_io_core_limit = {{ include "flavius.toCores" .Values.cn.resources.limits.cpu }}
     query_resource_group_default_concurrency_limit = {{ .Values.ms.resources.query_resource_group_default_concurrency_limit }}
-    query_resource_group_default_cpu_used_permille_limit = {{ include "flavius.toBytes" .Values.cn.resources.limits.memory }}
+    query_resource_group_default_cpu_used_permille_limit = {{ .Values.ms.resources.query_resource_group_default_cpu_used_permille_limit }}
     query_resource_group_default_memory_percent_limit = {{ .Values.ms.resources.query_resource_group_default_memory_percent_limit }}
     query_resource_group_default_enable_queue = {{ .Values.ms.resources.query_resource_group_default_enable_queue }}
     query_resource_group_default_queue_concurrency_limit = {{ .Values.ms.resources.query_resource_group_default_queue_concurrency_limit }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit configuration for the query resource group CPU usage limit via chart values, enabling easier and more predictable tuning without relying on memory-derived calculations.

* **Chores**
  * Updated configuration templating to use the new CPU limit value, aligning Helm values with runtime behavior and simplifying deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->