### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/etcd/values-aliyun.yaml
+++ b/etcd/values-aliyun.yaml
@@ -689,8 +689,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r30
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
     ##

--- a/etcd/values.yaml
+++ b/etcd/values.yaml
@@ -672,8 +672,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r30
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
     ##


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/os-shell:12-debian-12-r30` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default init container image used for volume permission setup to a newer, alternate image source.
  * Applied the same image update across the standard and Aliyun configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->